### PR TITLE
Safe spawn the players on server start

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.18.4
 loom_version=1.14-SNAPSHOT
 
 # Mod Properties
-mod_version=1.1.3
+mod_version=1.1.4
 maven_group=net.zenzty.soullink
 archives_base_name=soullink
 

--- a/src/main/java/net/zenzty/soullink/RunManager.java
+++ b/src/main/java/net/zenzty/soullink/RunManager.java
@@ -629,7 +629,7 @@ public class RunManager {
     /**
      * Teleports a player to the vanilla overworld spawn.
      */
-    private void teleportToVanillaSpawn(ServerPlayerEntity player) {
+    public void teleportToVanillaSpawn(ServerPlayerEntity player) {
         ServerWorld overworld = server.getOverworld();
         int y = overworld.getTopY(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, 0, 0);
         if (y < 1) y = 64;

--- a/src/main/java/net/zenzty/soullink/SoulLink.java
+++ b/src/main/java/net/zenzty/soullink/SoulLink.java
@@ -185,13 +185,19 @@ public class SoulLink implements ModInitializer {
                 return;
             }
             
-            // Delay handling to ensure player is fully loaded
+            // IMMEDIATELY teleport if IDLE to prevent suffocation damage
+            // (handles server restart mid-run where player coords were saved from temp world)
+            if (runManager.getGameState() == RunManager.GameState.IDLE) {
+                runManager.teleportToVanillaSpawn(player);
+            }
+            
+            // Delay other handling to ensure player is fully loaded
             scheduleDelayed(server, 10, () -> {
                 RunManager.GameState state = runManager.getGameState();
                 
                 switch (state) {
                     case IDLE:
-                        // No run active - show welcome message
+                        // Already teleported above, just show welcome message
                         sendWelcomeMessage(player);
                         break;
                         


### PR DESCRIPTION
Modify teleportToVanillaSpawn method visibility in RunManager to public, allowing direct access for immediate player teleportation during IDLE state in SoulLink.