### PR TITLE
Add death message broadcasting feature. Players will now receive a forrmatted death message upon lethal damage.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.18.4
 loom_version=1.14-SNAPSHOT
 
 # Mod Properties
-mod_version=1.1.4
+mod_version=1.1.5
 maven_group=net.zenzty.soullink
 archives_base_name=soullink
 

--- a/src/main/java/net/zenzty/soullink/SoulLink.java
+++ b/src/main/java/net/zenzty/soullink/SoulLink.java
@@ -386,6 +386,13 @@ public class SoulLink implements ModInitializer {
                         "Lethal damage detected for {} ({} damage, {} health) - triggering game over!",
                         player.getName().getString(), amount, currentHealth);
 
+                // Broadcast death message to all players (use vanilla death message format)
+                Text deathMessage = source.getDeathMessage(player);
+                Text formattedDeathMessage = Text.empty().append(RunManager.getPrefix())
+                        .append(Text.literal("☠ ").formatted(Formatting.DARK_RED))
+                        .append(deathMessage.copy().formatted(Formatting.RED));
+                runManager.getServer().getPlayerManager().broadcast(formattedDeathMessage, false);
+
                 // Heal player to max so they don't look dead
                 player.setHealth(player.getMaxHealth());
 
@@ -423,6 +430,15 @@ public class SoulLink implements ModInitializer {
                         LOGGER.warn(
                                 "Player {} reached 0 health despite ALLOW_DAMAGE check - triggering game over",
                                 player.getName().getString());
+
+                        // Broadcast death message to all players (use vanilla death message format)
+                        Text deathMessage = source.getDeathMessage(player);
+                        Text formattedDeathMessage = Text.empty().append(RunManager.getPrefix())
+                                .append(Text.literal("☠ ").formatted(Formatting.DARK_RED))
+                                .append(deathMessage.copy().formatted(Formatting.RED));
+                        runManager.getServer().getPlayerManager().broadcast(formattedDeathMessage,
+                                false);
+
                         player.setHealth(player.getMaxHealth());
                         runManager.triggerGameOver();
                         return;


### PR DESCRIPTION
When a player receives lethal damage, a chat message is now broadcast to all players showing who died and from what source.