### PR TITLE
feat: Add /reset command to manually reset the current run

### DIFF
--- a/src/main/java/net/zenzty/soullink/SoulLink.java
+++ b/src/main/java/net/zenzty/soullink/SoulLink.java
@@ -149,12 +149,12 @@ public class SoulLink implements ModInitializer {
                     return 0;
                 }
 
-                // Broadcast reset message to all players
-                runManager.getServer().getPlayerManager()
-                        .broadcast(RunManager.formatMessage("Run has been reset."), false);
-
+                // Perform the reset first
                 runManager.triggerGameOver();
 
+                // Broadcast reset message to all players after successful reset
+                runManager.getServer().getPlayerManager()
+                        .broadcast(RunManager.formatMessage("Run has been reset."), false);
                 return Command.SINGLE_SUCCESS;
             }));
         });


### PR DESCRIPTION
- Implemented a new command that allows players to reset the active run without requiring gamemaster permissions.
- Added checks to ensure a run is active before allowing the reset.
- Broadcasts a message to all players when the run is reset.