### PR TITLE
feat: Add normalization for regeneration effect healing in SharedStat…

### DIFF
--- a/src/main/java/net/zenzty/soullink/mixin/player/LivingEntityMixin.java
+++ b/src/main/java/net/zenzty/soullink/mixin/player/LivingEntityMixin.java
@@ -62,6 +62,10 @@ public abstract class LivingEntityMixin {
         if (isNaturalRegen) {
             // Let SharedStatsHandler handle the normalized regen
             SharedStatsHandler.onNaturalRegen(player, applied);
+        } else if (player.hasStatusEffect(StatusEffects.REGENERATION)) {
+            // Regeneration effect healing - normalize by player count to prevent multiplication
+            // when regeneration is synced to all players
+            SharedStatsHandler.onRegenerationHeal(player, applied);
         } else {
             // Larger heals (potions, golden apples) sync normally
             SharedStatsHandler.onPlayerHealed(player, player.getHealth());


### PR DESCRIPTION
- Implemented a new method, onRegenerationHeal, to handle healing from regeneration effects, normalizing the healing amount based on the number of players in the run.
- Introduced a regenerationHealAccumulator to manage fractional healing and prevent excessive updates.
- Updated LivingEntityMixin to call onRegenerationHeal when a player has the regeneration status effect, ensuring consistent healing behavior across players.