### PR TITLE
fix: clear Ender Dragon bossbar when starting a new run

### DIFF
--- a/src/main/java/net/zenzty/soullink/mixin/server/EnderDragonFightAccessor.java
+++ b/src/main/java/net/zenzty/soullink/mixin/server/EnderDragonFightAccessor.java
@@ -1,0 +1,18 @@
+package net.zenzty.soullink.mixin.server;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import net.minecraft.entity.boss.ServerBossBar;
+import net.minecraft.entity.boss.dragon.EnderDragonFight;
+
+/**
+ * Accessor mixin to get the bossBar from EnderDragonFight. Needed to clear the boss bar when
+ * starting a new run, as the vanilla Ender Dragon bossbar persists if players start a new run
+ * before the game cleans it up naturally.
+ */
+@Mixin(EnderDragonFight.class)
+public interface EnderDragonFightAccessor {
+
+    @Accessor("bossBar")
+    ServerBossBar getBossBar();
+}

--- a/src/main/resources/soullink.mixins.json
+++ b/src/main/resources/soullink.mixins.json
@@ -16,7 +16,8 @@
 		"interaction.FireBlockMixin",
 		"ui.ScreenHandlerAccessor",
 		"ui.SpectatorInteractionMixin",
-		"server.ServerWorldAccessor"
+		"server.ServerWorldAccessor",
+		"server.EnderDragonFightAccessor"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the Ender Dragon boss bar would persist across different runs. The boss bar is now properly cleared when starting a new run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->