### PR TITLE
Fix/raid bossbar

### DIFF
--- a/src/main/java/net/zenzty/soullink/mixin/server/RaidAccessor.java
+++ b/src/main/java/net/zenzty/soullink/mixin/server/RaidAccessor.java
@@ -1,0 +1,18 @@
+package net.zenzty.soullink.mixin.server;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import net.minecraft.entity.boss.ServerBossBar;
+import net.minecraft.village.raid.Raid;
+
+/**
+ * Accessor mixin to get the bar from Raid. Needed to clear the raid boss bar when starting a new
+ * run, as the vanilla raid bossbar persists if players start a new run before the game cleans it up
+ * naturally.
+ */
+@Mixin(Raid.class)
+public interface RaidAccessor {
+
+    @Accessor("bar")
+    ServerBossBar getBar();
+}

--- a/src/main/java/net/zenzty/soullink/mixin/server/RaidManagerAccessor.java
+++ b/src/main/java/net/zenzty/soullink/mixin/server/RaidManagerAccessor.java
@@ -1,0 +1,18 @@
+package net.zenzty.soullink.mixin.server;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import net.minecraft.village.raid.Raid;
+import net.minecraft.village.raid.RaidManager;
+
+/**
+ * Accessor mixin to get the raids map from RaidManager. Needed to iterate through all active raids
+ * to clear their bossbars when starting a new run.
+ */
+@Mixin(RaidManager.class)
+public interface RaidManagerAccessor {
+
+    @Accessor("raids")
+    Int2ObjectMap<Raid> getRaids();
+}

--- a/src/main/java/net/zenzty/soullink/server/run/RunManager.java
+++ b/src/main/java/net/zenzty/soullink/server/run/RunManager.java
@@ -2,7 +2,6 @@ package net.zenzty.soullink.server.run;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import net.minecraft.entity.boss.ServerBossBar;
 import net.minecraft.entity.boss.dragon.EnderDragonFight;
 import net.minecraft.network.packet.s2c.play.SubtitleS2CPacket;
@@ -25,6 +24,8 @@ import net.minecraft.world.GameMode;
 import net.minecraft.world.World;
 import net.zenzty.soullink.SoulLink;
 import net.zenzty.soullink.mixin.server.EnderDragonFightAccessor;
+import net.zenzty.soullink.mixin.server.RaidAccessor;
+import net.zenzty.soullink.mixin.server.RaidManagerAccessor;
 import net.zenzty.soullink.server.health.SharedStatsHandler;
 import net.zenzty.soullink.server.settings.Settings;
 
@@ -426,6 +427,8 @@ public class RunManager {
      * bossbar's internal player list (e.g., when they died).
      */
     private void forceClearBossBar(ServerBossBar bossBar) {
+        // Set invisible first to prevent the bossbar from being re-shown by ongoing game logic
+        bossBar.setVisible(false);
         // Add all online players to the bossbar first to ensure they're in the player list
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
             bossBar.addPlayer(player);
@@ -436,11 +439,11 @@ public class RunManager {
 
     /**
      * Clears all raid bossbars from all players. This is needed when starting a new run before
-     * Minecraft has naturally cleaned up the raid bossbars from a completed or abandoned run.
+     * Minecraft has naturally cleaned up the raid bossbars from a completed or abandoned run. Note:
+     * This method must be called from the server main thread. It uses a two-pass approach to avoid
+     * ConcurrentModificationException when invalidating raids.
      */
     private void clearRaidBossbars() {
-        int raidsCleared = 0;
-
         // Check all worlds for active raids and clear their bossbars
         for (ServerWorld world : server.getWorlds()) {
             RaidManager raidManager = world.getRaidManager();
@@ -448,68 +451,26 @@ public class RunManager {
                 continue;
             }
 
-            try {
-                // Use reflection to access the private raids field
-                // Note: The field type is Int2ObjectMap (FastUtil), which implements Map
-                java.lang.reflect.Field raidsField = null;
-                for (java.lang.reflect.Field field : raidManager.getClass().getDeclaredFields()) {
-                    if (Map.class.isAssignableFrom(field.getType())) {
-                        raidsField = field;
-                        break;
+            // Pass 1: Collect raids into a temporary list to avoid concurrent modification
+            List<Raid> raidsToClean =
+                    new ArrayList<>(((RaidManagerAccessor) raidManager).getRaids().values());
+
+            // Pass 2: Invalidate each raid and clear its bossbar
+            for (Raid raid : raidsToClean) {
+                try {
+                    // Invalidate the raid to stop it from ticking and re-showing the bossbar
+                    raid.invalidate();
+
+                    ServerBossBar bossBar = ((RaidAccessor) raid).getBar();
+                    if (bossBar != null) {
+                        forceClearBossBar(bossBar);
+                        SoulLink.LOGGER.debug("Cleared raid bossbar from world: {}",
+                                world.getRegistryKey().getValue());
                     }
+                } catch (Exception e) {
+                    SoulLink.LOGGER.warn("Failed to clear raid bossbar: {}", e.getMessage());
                 }
-
-                if (raidsField == null) {
-                    continue;
-                }
-
-                raidsField.setAccessible(true);
-                Object raidsObject = raidsField.get(raidManager);
-
-                if (!(raidsObject instanceof Map<?, ?> raidsMap)) {
-                    continue;
-                }
-
-                for (Object value : raidsMap.values()) {
-                    if (!(value instanceof Raid raid)) {
-                        continue;
-                    }
-
-                    try {
-                        // Use reflection to access the private bar field
-                        java.lang.reflect.Field barField = null;
-                        for (java.lang.reflect.Field field : raid.getClass().getDeclaredFields()) {
-                            if (field.getType() == ServerBossBar.class) {
-                                barField = field;
-                                break;
-                            }
-                        }
-
-                        if (barField == null) {
-                            continue;
-                        }
-
-                        barField.setAccessible(true);
-                        Object barObject = barField.get(raid);
-
-                        if (barObject instanceof ServerBossBar bossBar) {
-                            forceClearBossBar(bossBar);
-                            raidsCleared++;
-                            SoulLink.LOGGER.debug("Cleared raid bossbar from world: {}",
-                                    world.getRegistryKey().getValue());
-                        }
-                    } catch (Exception e) {
-                        SoulLink.LOGGER.warn("Failed to clear raid bossbar: {}", e.getMessage());
-                    }
-                }
-            } catch (Exception e) {
-                SoulLink.LOGGER.warn("Failed to access raids in world {}: {}",
-                        world.getRegistryKey().getValue(), e.getMessage());
             }
-        }
-
-        if (raidsCleared > 0) {
-            SoulLink.LOGGER.debug("Cleared {} raid bossbar(s)", raidsCleared);
         }
     }
 

--- a/src/main/resources/soullink.mixins.json
+++ b/src/main/resources/soullink.mixins.json
@@ -17,7 +17,9 @@
 		"ui.ScreenHandlerAccessor",
 		"ui.SpectatorInteractionMixin",
 		"server.ServerWorldAccessor",
-		"server.EnderDragonFightAccessor"
+		"server.EnderDragonFightAccessor",
+		"server.RaidAccessor",
+		"server.RaidManagerAccessor"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed raid boss bars persisting between runs - Previously, boss bars from active raids would remain visible when starting a new gameplay run. This issue has been resolved, and raid boss bars are now properly cleared on startup, ensuring a clean interface for each new session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->