### PR TITLE
feat: Implement Manhunt mode with role selection and compass tracking

### DIFF
--- a/src/main/java/net/zenzty/soullink/mixin/ui/SpectatorInteractionMixin.java
+++ b/src/main/java/net/zenzty/soullink/mixin/ui/SpectatorInteractionMixin.java
@@ -9,12 +9,13 @@ import net.minecraft.network.packet.c2s.play.ClickSlotC2SPacket;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.GameMode;
+import net.zenzty.soullink.server.manhunt.SpeedrunnerSelectorGui;
 import net.zenzty.soullink.server.settings.SettingsGui;
 import net.zenzty.soullink.server.settings.SettingsInfoGui;
 
 /**
- * Mixin to allow spectators to interact with Soul Link GUIs (chaos settings and info settings).
- * Normally, spectators cannot click on inventory slots.
+ * Mixin to allow spectators to interact with Soul Link GUIs: chaos settings, info settings, and the
+ * Runner/Hunter selector (Manhunt). Normally, spectators cannot click on inventory slots.
  */
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class SpectatorInteractionMixin {
@@ -23,9 +24,9 @@ public abstract class SpectatorInteractionMixin {
     public ServerPlayerEntity player;
 
     /**
-     * Intercepts inventory click packets to allow spectators to use the settings GUI. This mixin
-     * only bypasses the spectator check and delegates all logic to the ScreenHandler. All packet
-     * synchronization must originate from the ScreenHandler to maintain revision counter integrity.
+     * Intercepts inventory click packets to allow spectators to use Soul Link GUIs. Only bypasses
+     * the spectator check; all logic runs in the ScreenHandler. Packet sync must originate from the
+     * ScreenHandler to keep revision counters correct.
      */
     @Inject(method = "onClickSlot", at = @At("HEAD"), cancellable = true)
     private void onClickSlotSpectator(ClickSlotC2SPacket packet, CallbackInfo ci) {
@@ -34,7 +35,7 @@ public abstract class SpectatorInteractionMixin {
             return;
         }
 
-        // Check if player is using our chaos settings GUI or info settings GUI
+        // Chaos settings, info settings, or Runner/Hunter selector
         if (player.currentScreenHandler instanceof SettingsGui.SettingsScreenHandler handler) {
             // Basic validation - check if the packet's syncId matches the current handler
             // Most other validation (slot bounds, etc.) is handled inside onSlotClick
@@ -43,6 +44,11 @@ public abstract class SpectatorInteractionMixin {
                 ci.cancel();
             }
         } else if (player.currentScreenHandler instanceof SettingsInfoGui.InfoSettingsScreenHandler handler) {
+            if (packet.syncId() == handler.syncId) {
+                handler.onSlotClick(packet.slot(), packet.button(), packet.actionType(), player);
+                ci.cancel();
+            }
+        } else if (player.currentScreenHandler instanceof SpeedrunnerSelectorGui.SelectorScreenHandler handler) {
             if (packet.syncId() == handler.syncId) {
                 handler.onSlotClick(packet.slot(), packet.button(), packet.actionType(), player);
                 ci.cancel();

--- a/src/main/java/net/zenzty/soullink/server/command/CommandRegistry.java
+++ b/src/main/java/net/zenzty/soullink/server/command/CommandRegistry.java
@@ -9,7 +9,9 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.zenzty.soullink.server.health.SharedStatsHandler;
+import net.zenzty.soullink.server.manhunt.SpeedrunnerSelectorGui;
 import net.zenzty.soullink.server.run.RunManager;
+import net.zenzty.soullink.server.settings.Settings;
 import net.zenzty.soullink.server.settings.SettingsGui;
 import net.zenzty.soullink.server.settings.SettingsInfoGui;
 
@@ -70,10 +72,20 @@ public class CommandRegistry {
                         return 0;
                 }
 
-                // Start the run
-                runManager.startRun();
+                // Manhunt disabled (including pending): start immediately without opening the selector
+                if (!Settings.getInstance().isManhuntModeForNextRun()) {
+                        runManager.startRun();
+                        return Command.SINGLE_SUCCESS;
+                }
 
-                return Command.SINGLE_SUCCESS;
+                // Manhunt enabled: open the Runner/Hunter selector; startRun is called from the GUI on confirm
+                if (context.getSource().getEntity() instanceof ServerPlayerEntity player) {
+                        SpeedrunnerSelectorGui.open(player);
+                        return Command.SINGLE_SUCCESS;
+                }
+                context.getSource().sendError(
+                                RunManager.formatMessage("Only players can start a Manhunt run."));
+                return 0;
         }
 
         private static int handleStopRun(CommandContext<ServerCommandSource> context) {

--- a/src/main/java/net/zenzty/soullink/server/event/EventRegistry.java
+++ b/src/main/java/net/zenzty/soullink/server/event/EventRegistry.java
@@ -433,9 +433,11 @@ public class EventRegistry {
                 .append(deathMessage.copy().formatted(Formatting.RED));
         server.getPlayerManager().broadcast(formatted, false);
 
-        player.getStatusEffects().stream().filter(e -> !e.getEffectType().value().isBeneficial())
-                .map(e -> e.getEffectType()).toList().forEach(player::removeStatusEffect);
-        player.extinguish();
+        List<net.minecraft.registry.entry.RegistryEntry<net.minecraft.entity.effect.StatusEffect>> toRemove =
+                player.getStatusEffects().stream()
+                        .filter(e -> !e.getEffectType().value().isBeneficial())
+                        .map(e -> e.getEffectType()).toList();
+        toRemove.forEach(player::removeStatusEffect);
 
         player.changeGameMode(GameMode.SPECTATOR);
 
@@ -461,8 +463,8 @@ public class EventRegistry {
             scheduleDelayed((5 - i) * 20, () -> {
                 if (player.isRemoved() || !runManager.isRunActive())
                     return;
-                player.networkHandler.sendPacket(new TitleS2CPacket(
-                        Text.literal(String.valueOf(c)).formatted(Formatting.RED, Formatting.BOLD)));
+                player.networkHandler.sendPacket(new TitleS2CPacket(Text.literal(String.valueOf(c))
+                        .formatted(Formatting.RED, Formatting.BOLD)));
                 player.networkHandler.sendPacket(new SubtitleS2CPacket(
                         Text.literal("Respawning...").formatted(Formatting.GRAY)));
             });
@@ -493,9 +495,8 @@ public class EventRegistry {
             }
 
             if (targetWorld != null && targetPos != null) {
-                WorldProperties.SpawnPoint sp =
-                        WorldProperties.SpawnPoint.create(
-                                targetWorld.getRegistryKey(), targetPos, 0.0f, 0.0f);
+                WorldProperties.SpawnPoint sp = WorldProperties.SpawnPoint
+                        .create(targetWorld.getRegistryKey(), targetPos, 0.0f, 0.0f);
                 player.setSpawnPoint(new ServerPlayerEntity.Respawn(sp, true), false);
                 player.teleport(targetWorld, targetPos.getX() + 0.5, targetPos.getY(),
                         targetPos.getZ() + 0.5, Set.of(), 0.0f, 0.0f, true);

--- a/src/main/java/net/zenzty/soullink/server/event/EventRegistry.java
+++ b/src/main/java/net/zenzty/soullink/server/event/EventRegistry.java
@@ -3,13 +3,19 @@ package net.zenzty.soullink.server.event;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.boss.dragon.EnderDragonEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.network.packet.s2c.play.SubtitleS2CPacket;
+import net.minecraft.network.packet.s2c.play.TitleS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -18,12 +24,18 @@ import net.minecraft.text.HoverEvent;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.GameMode;
+import net.minecraft.world.WorldProperties;
 import net.zenzty.soullink.SoulLink;
 import net.zenzty.soullink.common.SoulLinkConstants;
 import net.zenzty.soullink.server.health.SharedJumpHandler;
 import net.zenzty.soullink.server.health.SharedStatsHandler;
+import net.zenzty.soullink.server.manhunt.CompassTrackingHandler;
+import net.zenzty.soullink.server.manhunt.ManhuntManager;
 import net.zenzty.soullink.server.run.RunManager;
 import net.zenzty.soullink.server.run.RunState;
+import net.zenzty.soullink.server.settings.Settings;
 
 /**
  * Registers all Fabric events: server lifecycle, player connections, tick updates, entity events.
@@ -51,6 +63,7 @@ public class EventRegistry {
         registerConnectionEvents();
         registerTickEvents();
         registerEntityEvents();
+        CompassTrackingHandler.register();
     }
 
     /**
@@ -61,6 +74,8 @@ public class EventRegistry {
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             SoulLink.LOGGER.info("Server started - initializing RunManager");
             RunManager.init(server);
+            ManhuntManager.getInstance().resetRoles();
+            ManhuntManager.getInstance().cleanupTeams(server);
         });
 
         // Server stopping - cleanup worlds
@@ -240,7 +255,6 @@ public class EventRegistry {
      */
     private static void registerTickEvents() {
         ServerTickEvents.END_SERVER_TICK.register(server -> {
-            // Process any delayed tasks first
             processDelayedTasks(server);
 
             RunManager runManager;
@@ -251,14 +265,13 @@ public class EventRegistry {
             }
 
             if (runManager != null) {
-                // Update run manager (handles generation, timer, etc.)
                 runManager.tick();
+                if (runManager.isRunActive() && Settings.getInstance().isManhuntMode()) {
+                    CompassTrackingHandler.tick(server);
+                }
             }
 
-            // Process shared jumps at tick end (prevents race conditions with latency)
             SharedJumpHandler.processJumpsAtTickEnd(server);
-
-            // Periodic stats sync
             SharedStatsHandler.tickSync(server);
         });
     }
@@ -353,15 +366,16 @@ public class EventRegistry {
                         return;
                     }
 
-                    // If player health hit 0 or below (shouldn't happen - mixin should catch this)
-                    // This is a backup check - ServerPlayerEntityMixin.preventDeathDuringRun should
-                    // have already cancelled onDeath() and triggered game over
                     if (player.getHealth() <= 0) {
                         SoulLink.LOGGER.warn(
-                                "Player {} reached 0 health despite mixin check - triggering game over",
+                                "Player {} reached 0 health despite mixin check - triggering death handler",
                                 player.getName().getString());
-
-                        handlePlayerDeath(player, source, runManager);
+                        if (Settings.getInstance().isManhuntMode()
+                                && ManhuntManager.getInstance().isHunter(player)) {
+                            handleHunterDeath(player, source, runManager);
+                        } else {
+                            handlePlayerDeath(player, source, runManager);
+                        }
                         return;
                     }
 
@@ -371,6 +385,11 @@ public class EventRegistry {
                     }
 
                     if (!runManager.isTemporaryWorld(playerWorld.getRegistryKey())) {
+                        return;
+                    }
+
+                    if (Settings.getInstance().isManhuntMode()
+                            && ManhuntManager.getInstance().isHunter(player)) {
                         return;
                     }
 
@@ -394,15 +413,117 @@ public class EventRegistry {
     }
 
     /**
+     * Handles Hunter death in Manhunt: broadcast, clear bad effects, switch to spectator, drop
+     * non-compass items, 5s countdown, then respawn at run spawn with full stats and a new tracking
+     * compass.
+     *
+     * @param player the hunter who died
+     * @param source the damage source
+     * @param runManager the run manager (used for spawn, run state, and overworld)
+     */
+    public static void handleHunterDeath(ServerPlayerEntity player, DamageSource source,
+            RunManager runManager) {
+        MinecraftServer server = runManager.getServer();
+        if (server == null)
+            return;
+
+        Text deathMessage = source.getDeathMessage(player);
+        Text formatted = Text.empty().append(RunManager.getPrefix())
+                .append(Text.literal("☠ ").formatted(Formatting.DARK_RED))
+                .append(deathMessage.copy().formatted(Formatting.RED));
+        server.getPlayerManager().broadcast(formatted, false);
+
+        player.getStatusEffects().stream().filter(e -> !e.getEffectType().value().isBeneficial())
+                .map(e -> e.getEffectType()).toList().forEach(player::removeStatusEffect);
+        player.extinguish();
+
+        player.changeGameMode(GameMode.SPECTATOR);
+
+        ServerWorld world = player.getEntityWorld();
+        double x = player.getX(), y = player.getY(), z = player.getZ();
+
+        for (int i = 0; i < player.getInventory().size(); i++) {
+            ItemStack stack = player.getInventory().getStack(i);
+            if (!stack.isEmpty() && !stack.isOf(Items.COMPASS)) {
+                ItemEntity ent = new ItemEntity(world, x, y, z, stack.copy());
+                ent.setVelocity(world.getRandom().nextGaussian() * 0.05,
+                        world.getRandom().nextGaussian() * 0.05 + 0.2,
+                        world.getRandom().nextGaussian() * 0.05);
+                world.spawnEntity(ent);
+            }
+        }
+
+        player.getInventory().clear();
+        player.getEnderChestInventory().clear();
+
+        for (int i = 5; i >= 1; i--) {
+            final int c = i;
+            scheduleDelayed((5 - i) * 20, () -> {
+                if (player.isRemoved() || !runManager.isRunActive())
+                    return;
+                player.networkHandler.sendPacket(new TitleS2CPacket(
+                        Text.literal(String.valueOf(c)).formatted(Formatting.RED, Formatting.BOLD)));
+                player.networkHandler.sendPacket(new SubtitleS2CPacket(
+                        Text.literal("Respawning...").formatted(Formatting.GRAY)));
+            });
+        }
+
+        scheduleDelayed(5 * 20, () -> {
+            if (player.isRemoved() || !runManager.isRunActive())
+                return;
+
+            player.networkHandler.sendPacket(new TitleS2CPacket(
+                    Text.literal("RESPAWN").formatted(Formatting.GREEN, Formatting.BOLD)));
+
+            player.changeGameMode(GameMode.SURVIVAL);
+
+            ServerWorld targetWorld = runManager.getTemporaryOverworld();
+            BlockPos targetPos = runManager.getSpawnPos();
+
+            ServerPlayerEntity.Respawn resp = player.getRespawn();
+            if (resp != null) {
+                var data = resp.respawnData();
+                if (data != null && runManager.isTemporaryWorld(data.getDimension())) {
+                    ServerWorld sw = server.getWorld(data.getDimension());
+                    if (sw != null) {
+                        targetWorld = sw;
+                        targetPos = data.getPos();
+                    }
+                }
+            }
+
+            if (targetWorld != null && targetPos != null) {
+                WorldProperties.SpawnPoint sp =
+                        WorldProperties.SpawnPoint.create(
+                                targetWorld.getRegistryKey(), targetPos, 0.0f, 0.0f);
+                player.setSpawnPoint(new ServerPlayerEntity.Respawn(sp, true), false);
+                player.teleport(targetWorld, targetPos.getX() + 0.5, targetPos.getY(),
+                        targetPos.getZ() + 0.5, Set.of(), 0.0f, 0.0f, true);
+            }
+
+            player.setHealth(player.getMaxHealth());
+            player.getHungerManager().setFoodLevel(20);
+            player.getHungerManager().setSaturationLevel(5.0f);
+
+            CompassTrackingHandler.giveTrackingCompass(player);
+
+            SoulLink.LOGGER.info("Hunter {} respawned after death", player.getName().getString());
+        });
+    }
+
+    /**
      * Schedule a task to run after a delay in ticks.
      */
     public static void scheduleDelayed(int delayTicks, Runnable task) {
         delayedTasks.add(new DelayedTask(delayTicks, task));
     }
 
-    // Kept for backward compatibility if needed, but redirects to the new one
-    public static void scheduleDelayed(MinecraftServer server, int delayTicks, Runnable task) {
-        scheduleDelayed(delayTicks, task);
+    /**
+     * Clears all pending delayed tasks. Called when starting a new run so that tasks from a
+     * previous run (e.g. hunter respawn countdown) do not carry over.
+     */
+    public static void clearDelayedTasks() {
+        delayedTasks.clear();
     }
 
     /**

--- a/src/main/java/net/zenzty/soullink/server/health/SharedStatsHandler.java
+++ b/src/main/java/net/zenzty/soullink/server/health/SharedStatsHandler.java
@@ -1,20 +1,22 @@
 package net.zenzty.soullink.server.health;
 
 import java.util.List;
+import java.util.Locale;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.math.MathHelper;
 import net.zenzty.soullink.SoulLink;
+import net.zenzty.soullink.server.manhunt.ManhuntManager;
 import net.zenzty.soullink.server.run.RunManager;
 import net.zenzty.soullink.server.settings.Settings;
 
-// Note: Settings import is used for half heart mode max health calculations
-
 /**
  * Handles shared health, hunger, and saturation between all players. Implements the "Soul Link"
- * mechanic where all players share the same vital stats.
+ * mechanic where all players share the same vital stats. In Manhunt mode, only Runners participate.
  */
 public class SharedStatsHandler {
 
@@ -45,6 +47,28 @@ public class SharedStatsHandler {
      */
     private static float getMaxHealth() {
         return Settings.getInstance().isHalfHeartMode() ? 1.0f : 20.0f;
+    }
+
+    /**
+     * Returns whether this player participates in shared Soul Link stats. When Manhunt is off, all
+     * players in the run participate. When Manhunt is on, only Runners participate; Hunters use
+     * vanilla mechanics.
+     *
+     * @param player the player to check
+     * @return true if the player should share health, hunger, and related stats
+     */
+    private static boolean shouldParticipateInSoulLink(ServerPlayerEntity player) {
+        RunManager runManager;
+        try {
+            runManager = RunManager.getInstance();
+        } catch (IllegalStateException e) {
+            return false;
+        }
+        if (!runManager.isRunActive())
+            return false;
+        if (!Settings.getInstance().isManhuntMode())
+            return true;
+        return ManhuntManager.getInstance().isSpeedrunner(player);
     }
 
     /**
@@ -115,6 +139,8 @@ public class SharedStatsHandler {
             DamageSource damageSource) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(damagedPlayer))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -124,7 +150,6 @@ public class SharedStatsHandler {
         if (playerWorld == null)
             return;
 
-        // Only process if in a temporary world
         if (!runManager.isTemporaryWorld(playerWorld.getRegistryKey()))
             return;
 
@@ -161,35 +186,32 @@ public class SharedStatsHandler {
                 List<ServerPlayerEntity> players = server.getPlayerManager().getPlayerList();
 
                 // Broadcast damage notification to all players (if combat log is enabled)
-                if (net.zenzty.soullink.server.settings.Settings.getInstance().isDamageLogEnabled()) {
-                    // Convert from half-hearts to full hearts for display (Minecraft stores health as
-                    // 0-20, where 1 heart = 2)
-                    // Round to nearest 0.5 hearts and ensure minimum of 0.5 for display
+                if (Settings.getInstance().isDamageLogEnabled()) {
+                    // Convert from half-hearts to full hearts for display (Minecraft stores health
+                    // as
+                    // 0-20, where 1 heart = 2). Round to nearest 0.5 hearts and ensure minimum 0.5.
                     float damageInHearts = syncedDamageAmount / 2.0f;
                     float roundedDamage = Math.max(0.5f, Math.round(damageInHearts * 2.0f) / 2.0f);
-                    String damageText = String.format(java.util.Locale.US, "%.1f", roundedDamage);
-                    net.minecraft.text.Text damageNotification = net.minecraft.text.Text.empty()
-                            .append(RunManager.getPrefix())
-                            .append(net.minecraft.text.Text.literal(damagedPlayer.getName().getString())
-                                    .formatted(net.minecraft.util.Formatting.WHITE))
-                            .append(net.minecraft.text.Text.literal(" has taken ")
-                                    .formatted(net.minecraft.util.Formatting.GRAY))
-                            .append(net.minecraft.text.Text.literal(damageText + " ❤")
-                                    .formatted(net.minecraft.util.Formatting.RED))
-                            .append(net.minecraft.text.Text.literal(" damage.")
-                                    .formatted(net.minecraft.util.Formatting.GRAY));
+                    String damageText = String.format(Locale.US, "%.1f", roundedDamage);
+                    Text damageNotification = Text.empty().append(RunManager.getPrefix())
+                            .append(Text.literal(damagedPlayer.getName().getString())
+                                    .formatted(Formatting.WHITE))
+                            .append(Text.literal(" has taken ").formatted(Formatting.GRAY))
+                            .append(Text.literal(damageText + " ❤").formatted(Formatting.RED))
+                            .append(Text.literal(" damage.").formatted(Formatting.GRAY));
                     server.getPlayerManager().broadcast(damageNotification, false);
                 }
 
                 for (ServerPlayerEntity player : players) {
                     if (player == damagedPlayer || player.isSpectator() || player.isCreative())
                         continue;
+                    if (!shouldParticipateInSoulLink(player))
+                        continue;
 
                     ServerWorld otherWorld = getPlayerWorld(player);
                     if (otherWorld == null)
                         continue;
 
-                    // Skip players not in the run
                     if (!runManager.isTemporaryWorld(otherWorld.getRegistryKey()))
                         continue;
 
@@ -231,9 +253,10 @@ public class SharedStatsHandler {
         if (server == null)
             return;
 
-        // Count players in the run
         int playerCount = 0;
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (!shouldParticipateInSoulLink(player))
+                continue;
             ServerWorld world = getPlayerWorld(player);
             if (world != null && runManager.isTemporaryWorld(world.getRegistryKey())) {
                 playerCount++;
@@ -243,7 +266,6 @@ public class SharedStatsHandler {
         if (playerCount == 0)
             return;
 
-        // Divide the damage by player count and accumulate
         float normalizedDamage = damageAmount / playerCount;
         damageAccumulator += normalizedDamage;
 
@@ -262,6 +284,8 @@ public class SharedStatsHandler {
 
             // Sync to all players
             for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                if (!shouldParticipateInSoulLink(player))
+                    continue;
                 ServerWorld otherWorld = getPlayerWorld(player);
                 if (otherWorld == null || !runManager.isTemporaryWorld(otherWorld.getRegistryKey()))
                     continue;
@@ -291,6 +315,8 @@ public class SharedStatsHandler {
     public static void onPlayerHealed(ServerPlayerEntity healedPlayer, float newHealth) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(healedPlayer))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -308,7 +334,6 @@ public class SharedStatsHandler {
             float oldHealth = sharedHealth;
             sharedHealth = MathHelper.clamp(newHealth, 0.0f, getMaxHealth());
 
-            // Only sync if health increased
             if (sharedHealth > oldHealth) {
                 MinecraftServer server = runManager.getServer();
                 if (server == null)
@@ -317,8 +342,9 @@ public class SharedStatsHandler {
                 for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
                     if (player == healedPlayer)
                         continue;
-
                     if (player.isSpectator() || player.isCreative())
+                        continue;
+                    if (!shouldParticipateInSoulLink(player))
                         continue;
 
                     ServerWorld otherWorld = getPlayerWorld(player);
@@ -349,6 +375,8 @@ public class SharedStatsHandler {
     public static void onRegenerationHeal(ServerPlayerEntity regenPlayer, float healAmount) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(regenPlayer))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -365,9 +393,10 @@ public class SharedStatsHandler {
         if (server == null)
             return;
 
-        // Count players in the run
         int playerCount = 0;
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (!shouldParticipateInSoulLink(player))
+                continue;
             ServerWorld world = getPlayerWorld(player);
             if (world != null && runManager.isTemporaryWorld(world.getRegistryKey())) {
                 playerCount++;
@@ -400,6 +429,8 @@ public class SharedStatsHandler {
                 if (sharedHealth > oldHealth) {
                     // Sync to all players
                     for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                        if (!shouldParticipateInSoulLink(player))
+                            continue;
                         ServerWorld otherWorld = getPlayerWorld(player);
                         if (otherWorld == null)
                             continue;
@@ -430,6 +461,8 @@ public class SharedStatsHandler {
     public static void onAbsorptionChanged(ServerPlayerEntity changedPlayer, float newAbsorption) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(changedPlayer))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -442,7 +475,6 @@ public class SharedStatsHandler {
         if (!runManager.isTemporaryWorld(playerWorld.getRegistryKey()))
             return;
 
-        // Only sync if absorption actually changed
         if (Math.abs(newAbsorption - sharedAbsorption) < 0.1f)
             return;
 
@@ -455,9 +487,10 @@ public class SharedStatsHandler {
             if (server == null)
                 return;
 
-            // Sync to all other players
             for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
                 if (player == changedPlayer)
+                    continue;
+                if (!shouldParticipateInSoulLink(player))
                     continue;
 
                 ServerWorld otherWorld = getPlayerWorld(player);
@@ -487,6 +520,8 @@ public class SharedStatsHandler {
     public static void onNaturalRegen(ServerPlayerEntity regenPlayer, float healAmount) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(regenPlayer))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -503,9 +538,10 @@ public class SharedStatsHandler {
         if (server == null)
             return;
 
-        // Count players in the run
         int playerCount = 0;
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (!shouldParticipateInSoulLink(player))
+                continue;
             ServerWorld world = getPlayerWorld(player);
             if (world != null && runManager.isTemporaryWorld(world.getRegistryKey())) {
                 playerCount++;
@@ -538,6 +574,8 @@ public class SharedStatsHandler {
                 if (sharedHealth > oldHealth) {
                     // Sync to all players
                     for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                        if (!shouldParticipateInSoulLink(player))
+                            continue;
                         ServerWorld otherWorld = getPlayerWorld(player);
                         if (otherWorld == null)
                             continue;
@@ -565,6 +603,8 @@ public class SharedStatsHandler {
             float newSaturation) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(player))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -579,7 +619,6 @@ public class SharedStatsHandler {
 
         isSyncing = true;
         try {
-            // Check if values actually changed
             boolean foodChanged = newFoodLevel != sharedHunger;
             boolean satChanged = Math.abs(newSaturation - sharedSaturation) > 0.01f;
 
@@ -596,6 +635,8 @@ public class SharedStatsHandler {
 
             for (ServerPlayerEntity otherPlayer : server.getPlayerManager().getPlayerList()) {
                 if (otherPlayer == player)
+                    continue;
+                if (!shouldParticipateInSoulLink(otherPlayer))
                     continue;
 
                 ServerWorld otherWorld = getPlayerWorld(otherPlayer);
@@ -627,6 +668,8 @@ public class SharedStatsHandler {
             float satDrain) {
         if (isSyncing)
             return;
+        if (!shouldParticipateInSoulLink(drainPlayer))
+            return;
 
         RunManager runManager = RunManager.getInstance();
         if (runManager == null || !runManager.isRunActive())
@@ -643,9 +686,10 @@ public class SharedStatsHandler {
         if (server == null)
             return;
 
-        // Count players in the run
         int playerCount = 0;
         for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (!shouldParticipateInSoulLink(player))
+                continue;
             ServerWorld world = getPlayerWorld(player);
             if (world != null && runManager.isTemporaryWorld(world.getRegistryKey())) {
                 playerCount++;
@@ -682,8 +726,9 @@ public class SharedStatsHandler {
                     saturationDrainAccumulator = 0.0f;
                 }
 
-                // Sync to all players
                 for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                    if (!shouldParticipateInSoulLink(player))
+                        continue;
                     ServerWorld otherWorld = getPlayerWorld(player);
                     if (otherWorld == null)
                         continue;
@@ -722,6 +767,8 @@ public class SharedStatsHandler {
         isSyncing = true;
         try {
             for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+                if (!shouldParticipateInSoulLink(player))
+                    continue;
                 ServerWorld playerWorld = getPlayerWorld(player);
                 if (playerWorld == null)
                     continue;
@@ -729,7 +776,6 @@ public class SharedStatsHandler {
                 if (!runManager.isTemporaryWorld(playerWorld.getRegistryKey()))
                     continue;
 
-                // If player's values drift from master, correct them
                 float playerHealth = player.getHealth();
                 float playerAbsorption = player.getAbsorptionAmount();
                 int playerFood = player.getHungerManager().getFoodLevel();

--- a/src/main/java/net/zenzty/soullink/server/manhunt/CompassTrackingHandler.java
+++ b/src/main/java/net/zenzty/soullink/server/manhunt/CompassTrackingHandler.java
@@ -1,0 +1,254 @@
+package net.zenzty.soullink.server.manhunt;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.LodestoneTrackerComponent;
+import net.minecraft.component.type.LoreComponent;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.math.GlobalPos;
+import net.minecraft.world.World;
+import net.zenzty.soullink.SoulLink;
+
+/**
+ * Handles compass tracking for hunters in Manhunt mode. Hunters right-click their compass to cycle
+ * between runners. If the tracked runner is in a different dimension, the compass points to their
+ * last known location in the hunter's dimension.
+ */
+public class CompassTrackingHandler {
+
+    private static final int UPDATE_INTERVAL_TICKS = 20;
+    /** Ticks to suppress the timer on the action bar after a compass tracking message (3 seconds). */
+    private static final int COMPASS_MESSAGE_TICKS = 60;
+    private static int tickCounter = 0;
+
+    private static final Map<UUID, UUID> hunterTargets = new HashMap<>();
+    private static final Map<UUID, Map<RegistryKey<World>, GlobalPos>> lastKnownPositions =
+            new HashMap<>();
+    /** Hunter UUID -> server tick until which the timer must not overwrite the action bar. */
+    private static final Map<UUID, Integer> actionBarSuppressUntilTick = new HashMap<>();
+
+    /**
+     * Registers the compass use event. Call this once during mod initialization.
+     */
+    public static void register() {
+        UseItemCallback.EVENT.register((player, world, hand) -> {
+            if (world.isClient()) {
+                return ActionResult.PASS;
+            }
+
+            if (!(player instanceof ServerPlayerEntity serverPlayer)) {
+                return ActionResult.PASS;
+            }
+
+            ItemStack stack = player.getStackInHand(hand);
+            if (!stack.isOf(Items.COMPASS)) {
+                return ActionResult.PASS;
+            }
+
+            ManhuntManager manhunt = ManhuntManager.getInstance();
+            if (!manhunt.isHunter(serverPlayer)) {
+                return ActionResult.PASS;
+            }
+
+            MinecraftServer server = serverPlayer.getEntityWorld().getServer();
+            if (server != null) {
+                cycleTarget(serverPlayer, server);
+            }
+
+            return ActionResult.SUCCESS;
+        });
+
+        SoulLink.LOGGER.info("Compass tracking handler registered");
+    }
+
+    /**
+     * Called every server tick to update runner positions and hunter compasses. Only run when
+     * Manhunt is active and a run is in progress.
+     */
+    public static void tick(MinecraftServer server) {
+        tickCounter++;
+        if (tickCounter < UPDATE_INTERVAL_TICKS) {
+            return;
+        }
+        tickCounter = 0;
+
+        ManhuntManager manhunt = ManhuntManager.getInstance();
+
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (manhunt.isSpeedrunner(player)) {
+                updateLastKnownPosition(player);
+            }
+        }
+
+        for (ServerPlayerEntity hunter : server.getPlayerManager().getPlayerList()) {
+            if (manhunt.isHunter(hunter)) {
+                updateCompassForHunter(hunter, server);
+            }
+        }
+    }
+
+    private static void updateLastKnownPosition(ServerPlayerEntity runner) {
+        UUID runnerId = runner.getUuid();
+        RegistryKey<World> dimension = runner.getEntityWorld().getRegistryKey();
+        GlobalPos currentPos = GlobalPos.create(dimension, runner.getBlockPos());
+
+        lastKnownPositions.computeIfAbsent(runnerId, k -> new HashMap<>())
+                .put(dimension, currentPos);
+    }
+
+    private static void cycleTarget(ServerPlayerEntity hunter, MinecraftServer server) {
+        ManhuntManager manhunt = ManhuntManager.getInstance();
+        List<ServerPlayerEntity> runners = new ArrayList<>();
+
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            if (manhunt.isSpeedrunner(player)) {
+                runners.add(player);
+            }
+        }
+
+        if (runners.isEmpty()) {
+            hunter.sendMessage(Text.literal("No runners to track!").formatted(Formatting.RED), true);
+            markCompassMessageShown(hunter.getUuid(), server);
+            return;
+        }
+
+        UUID hunterId = hunter.getUuid();
+        UUID currentTarget = hunterTargets.get(hunterId);
+
+        int currentIndex = -1;
+        if (currentTarget != null) {
+            for (int i = 0; i < runners.size(); i++) {
+                if (runners.get(i).getUuid().equals(currentTarget)) {
+                    currentIndex = i;
+                    break;
+                }
+            }
+        }
+
+        int nextIndex = (currentIndex + 1) % runners.size();
+        ServerPlayerEntity newTarget = runners.get(nextIndex);
+        hunterTargets.put(hunterId, newTarget.getUuid());
+
+        RegistryKey<World> hunterDimension = hunter.getEntityWorld().getRegistryKey();
+        RegistryKey<World> targetDimension = newTarget.getEntityWorld().getRegistryKey();
+
+        if (hunterDimension.equals(targetDimension)) {
+            hunter.sendMessage(Text.literal("Now tracking: ").formatted(Formatting.GRAY)
+                    .append(Text.literal(newTarget.getName().getString())
+                            .formatted(Formatting.RED, Formatting.BOLD)),
+                    true);
+        } else {
+            hunter.sendMessage(Text.literal("Target in another dimension - showing last location")
+                    .formatted(Formatting.YELLOW), true);
+        }
+        markCompassMessageShown(hunter.getUuid(), server);
+
+        updateCompassForHunter(hunter, server);
+
+        SoulLink.LOGGER.debug("Hunter {} now tracking runner {}", hunter.getName().getString(),
+                newTarget.getName().getString());
+    }
+
+    private static void updateCompassForHunter(ServerPlayerEntity hunter, MinecraftServer server) {
+        UUID targetId = hunterTargets.get(hunter.getUuid());
+        if (targetId == null) {
+            return;
+        }
+
+        ServerPlayerEntity runner = server.getPlayerManager().getPlayer(targetId);
+        GlobalPos targetPos = null;
+
+        if (runner != null) {
+            RegistryKey<World> hunterDimension = hunter.getEntityWorld().getRegistryKey();
+            RegistryKey<World> runnerDimension = runner.getEntityWorld().getRegistryKey();
+
+            if (hunterDimension.equals(runnerDimension)) {
+                targetPos = GlobalPos.create(runnerDimension, runner.getBlockPos());
+            } else {
+                Map<RegistryKey<World>, GlobalPos> runnerPositions =
+                        lastKnownPositions.get(targetId);
+                if (runnerPositions != null) {
+                    targetPos = runnerPositions.get(hunterDimension);
+                }
+            }
+        }
+
+        for (int i = 0; i < hunter.getInventory().size(); i++) {
+            ItemStack stack = hunter.getInventory().getStack(i);
+            if (stack.isOf(Items.COMPASS)) {
+                if (targetPos != null) {
+                    LodestoneTrackerComponent tracker =
+                            new LodestoneTrackerComponent(Optional.of(targetPos), false);
+                    stack.set(DataComponentTypes.LODESTONE_TRACKER, tracker);
+                } else {
+                    stack.remove(DataComponentTypes.LODESTONE_TRACKER);
+                }
+            }
+        }
+    }
+
+    /**
+     * Gives a tracking compass to a hunter.
+     */
+    public static void giveTrackingCompass(ServerPlayerEntity hunter) {
+        ItemStack compass = new ItemStack(Items.COMPASS);
+        compass.set(DataComponentTypes.CUSTOM_NAME, Text.literal("Runner Tracker")
+                .setStyle(Style.EMPTY.withFormatting(Formatting.RED).withItalic(false)));
+        compass.set(DataComponentTypes.LORE,
+                new LoreComponent(List.of(Text.literal("Right Click to swap target")
+                        .setStyle(Style.EMPTY.withFormatting(Formatting.GRAY).withItalic(false)))));
+        hunter.getInventory().insertStack(compass);
+        SoulLink.LOGGER.info("Gave tracking compass to hunter {}", hunter.getName().getString());
+    }
+
+    /**
+     * Marks that a compass tracking message was shown on the action bar. The timer will not
+     * overwrite it for 3 seconds.
+     */
+    private static void markCompassMessageShown(UUID hunterId, MinecraftServer server) {
+        actionBarSuppressUntilTick.put(hunterId, server.getTicks() + COMPASS_MESSAGE_TICKS);
+    }
+
+    /**
+     * Returns whether the timer should not be sent to this player on the action bar. Used in
+     * Manhunt so the "Now tracking: X" (and similar) compass messages stay visible for a few
+     * seconds instead of being overwritten on the next tick.
+     *
+     * @param playerId the player UUID (only hunters are ever recorded)
+     * @param currentTick the current server tick
+     * @return true to suppress the timer action bar for this player
+     */
+    public static boolean shouldSuppressTimerActionBar(UUID playerId, int currentTick) {
+        Integer until = actionBarSuppressUntilTick.get(playerId);
+        if (until == null) return false;
+        if (currentTick >= until) {
+            actionBarSuppressUntilTick.remove(playerId);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Resets all tracking state. Called when a new run starts or run ends.
+     */
+    public static void reset() {
+        tickCounter = 0;
+        hunterTargets.clear();
+        lastKnownPositions.clear();
+        actionBarSuppressUntilTick.clear();
+    }
+}

--- a/src/main/java/net/zenzty/soullink/server/manhunt/ManhuntManager.java
+++ b/src/main/java/net/zenzty/soullink/server/manhunt/ManhuntManager.java
@@ -1,0 +1,233 @@
+package net.zenzty.soullink.server.manhunt;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import net.minecraft.scoreboard.Scoreboard;
+import net.minecraft.scoreboard.Team;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.zenzty.soullink.SoulLink;
+
+/**
+ * Manages player roles in Manhunt mode. Runners share health/stats (Soul Link mechanic). Hunters
+ * operate with vanilla mechanics.
+ */
+public class ManhuntManager {
+
+    private static volatile ManhuntManager instance;
+
+    // Player roles
+    private final Set<UUID> runners = new HashSet<>();
+    private final Set<UUID> hunters = new HashSet<>();
+
+    // Team names for scoreboard
+    public static final String RUNNERS_TEAM = "soullink_runners";
+    public static final String HUNTERS_TEAM = "soullink_hunters";
+
+    private ManhuntManager() {}
+
+    public static synchronized ManhuntManager getInstance() {
+        if (instance == null) {
+            instance = new ManhuntManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Resets all player roles. Called on server start and when a new run begins.
+     */
+    public void resetRoles() {
+        runners.clear();
+        hunters.clear();
+        SoulLink.LOGGER.info("Manhunt roles reset");
+    }
+
+    /**
+     * Sets a player as a Runner (shares health/stats).
+     */
+    public void setRunner(UUID playerId) {
+        hunters.remove(playerId);
+        runners.add(playerId);
+        SoulLink.LOGGER.debug("Player {} set as Runner", playerId);
+    }
+
+    /**
+     * Sets a player as a Hunter (vanilla mechanics).
+     */
+    public void setHunter(UUID playerId) {
+        runners.remove(playerId);
+        hunters.add(playerId);
+        SoulLink.LOGGER.debug("Player {} set as Hunter", playerId);
+    }
+
+    /**
+     * Toggles player role and returns the new role (true = runner, false = hunter).
+     */
+    public boolean toggleRole(UUID playerId) {
+        if (runners.contains(playerId)) {
+            setHunter(playerId);
+            return false;
+        } else {
+            setRunner(playerId);
+            return true;
+        }
+    }
+
+    /**
+     * Checks if a player is a Runner (participates in Soul Link).
+     */
+    public boolean isSpeedrunner(ServerPlayerEntity player) {
+        return player != null && runners.contains(player.getUuid());
+    }
+
+    /**
+     * Checks if a player is a Runner by UUID.
+     */
+    public boolean isSpeedrunner(UUID playerId) {
+        return playerId != null && runners.contains(playerId);
+    }
+
+    /**
+     * Checks if a player is a Hunter (vanilla mechanics).
+     */
+    public boolean isHunter(ServerPlayerEntity player) {
+        return player != null && hunters.contains(player.getUuid());
+    }
+
+    /**
+     * Checks if a player is a Hunter by UUID.
+     */
+    public boolean isHunter(UUID playerId) {
+        return playerId != null && hunters.contains(playerId);
+    }
+
+    /**
+     * Gets all Runner UUIDs.
+     */
+    public Set<UUID> getRunners() {
+        return new HashSet<>(runners);
+    }
+
+    /**
+     * Gets all Hunter UUIDs.
+     */
+    public Set<UUID> getHunters() {
+        return new HashSet<>(hunters);
+    }
+
+    /**
+     * Checks if any runners have been assigned.
+     */
+    public boolean hasRunners() {
+        return !runners.isEmpty();
+    }
+
+    /**
+     * Checks if any hunters have been assigned.
+     */
+    public boolean hasHunters() {
+        return !hunters.isEmpty();
+    }
+
+    /**
+     * Creates scoreboard teams for Runners and Hunters. Teams provide colored name tags and
+     * prefixes.
+     */
+    public void createTeams(MinecraftServer server) {
+        if (server == null)
+            return;
+
+        Scoreboard scoreboard = server.getScoreboard();
+
+        // Create or get Runners team
+        Team runnersTeam = scoreboard.getTeam(RUNNERS_TEAM);
+        if (runnersTeam == null) {
+            runnersTeam = scoreboard.addTeam(RUNNERS_TEAM);
+        }
+        runnersTeam.setDisplayName(Text.literal("Runners"));
+        runnersTeam.setColor(Formatting.WHITE);
+        runnersTeam.setPrefix(Text.empty()
+                .append(Text.literal("Runner").formatted(Formatting.GREEN, Formatting.BOLD))
+                .append(Text.literal(" | ").formatted(Formatting.DARK_GRAY)));
+
+        // Create or get Hunters team
+        Team huntersTeam = scoreboard.getTeam(HUNTERS_TEAM);
+        if (huntersTeam == null) {
+            huntersTeam = scoreboard.addTeam(HUNTERS_TEAM);
+        }
+        huntersTeam.setDisplayName(Text.literal("Hunters"));
+        huntersTeam.setColor(Formatting.WHITE);
+        huntersTeam.setPrefix(Text.empty()
+                .append(Text.literal("Hunter").formatted(Formatting.RED, Formatting.BOLD))
+                .append(Text.literal(" | ").formatted(Formatting.DARK_GRAY)));
+
+        SoulLink.LOGGER.info("Manhunt teams created/updated");
+    }
+
+    /**
+     * Assigns all players to their respective scoreboard teams.
+     */
+    public void assignPlayersToTeams(MinecraftServer server) {
+        if (server == null)
+            return;
+
+        Scoreboard scoreboard = server.getScoreboard();
+        Team runnersTeam = scoreboard.getTeam(RUNNERS_TEAM);
+        Team huntersTeam = scoreboard.getTeam(HUNTERS_TEAM);
+
+        if (runnersTeam == null || huntersTeam == null) {
+            createTeams(server);
+            runnersTeam = scoreboard.getTeam(RUNNERS_TEAM);
+            huntersTeam = scoreboard.getTeam(HUNTERS_TEAM);
+        }
+
+        for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
+            String playerName = player.getGameProfile().name();
+
+            // Remove from any existing team first
+            Team currentTeam = scoreboard.getScoreHolderTeam(playerName);
+            if (currentTeam != null) {
+                scoreboard.removeScoreHolderFromTeam(playerName, currentTeam);
+            }
+
+            // Add to appropriate team
+            if (runners.contains(player.getUuid())) {
+                scoreboard.addScoreHolderToTeam(playerName, runnersTeam);
+            } else if (hunters.contains(player.getUuid())) {
+                scoreboard.addScoreHolderToTeam(playerName, huntersTeam);
+            }
+        }
+
+        SoulLink.LOGGER.info("Players assigned to teams: {} runners, {} hunters", runners.size(),
+                hunters.size());
+    }
+
+    /**
+     * Cleans up teams when run ends.
+     */
+    public void cleanupTeams(MinecraftServer server) {
+        if (server == null)
+            return;
+
+        Scoreboard scoreboard = server.getScoreboard();
+
+        // Remove all players from teams
+        Team runnersTeam = scoreboard.getTeam(RUNNERS_TEAM);
+        Team huntersTeam = scoreboard.getTeam(HUNTERS_TEAM);
+
+        if (runnersTeam != null) {
+            for (String member : new HashSet<>(runnersTeam.getPlayerList())) {
+                scoreboard.removeScoreHolderFromTeam(member, runnersTeam);
+            }
+        }
+
+        if (huntersTeam != null) {
+            for (String member : new HashSet<>(huntersTeam.getPlayerList())) {
+                scoreboard.removeScoreHolderFromTeam(member, huntersTeam);
+            }
+        }
+    }
+}

--- a/src/main/java/net/zenzty/soullink/server/manhunt/SpeedrunnerSelectorGui.java
+++ b/src/main/java/net/zenzty/soullink/server/manhunt/SpeedrunnerSelectorGui.java
@@ -1,0 +1,395 @@
+package net.zenzty.soullink.server.manhunt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.LoreComponent;
+import net.minecraft.component.type.ProfileComponent;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.SimpleNamedScreenHandlerFactory;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.world.GameMode;
+import net.zenzty.soullink.mixin.ui.ScreenHandlerAccessor;
+import net.zenzty.soullink.server.run.RunManager;
+
+/**
+ * GUI for selecting Runners and Hunters before starting a Manhunt run. Shows player heads that can
+ * be clicked to toggle roles. Accessible to spectators via SpectatorInteractionMixin.
+ */
+public class SpeedrunnerSelectorGui {
+
+    private static final int INVENTORY_SIZE = 54;
+    private static final int CONFIRM_SLOT = 49; // Bottom center
+
+    // Player head slots: top row and side columns (0, 8) are filler; content fills rows 1–5,
+    // cols 1–7 with no gaps. Confirm at 49; heads use the rest in row-major order.
+    private static final int[] HEAD_SLOTS = {
+            10, 11, 12, 13, 14, 15, 16,
+            19, 20, 21, 22, 23, 24, 25,
+            28, 29, 30, 31, 32, 33, 34,
+            37, 38, 39, 40, 41, 42, 43,
+            46, 47, 48, 50, 51, 52
+    };
+
+    /**
+     * Opens the role selector GUI for a player.
+     */
+    public static void open(ServerPlayerEntity player) {
+        MinecraftServer server = RunManager.getInstance().getServer();
+        if (server == null)
+            return;
+
+        // Reset roles when opening selector and default all to Runners
+        ManhuntManager.getInstance().resetRoles();
+        for (ServerPlayerEntity p : server.getPlayerManager().getPlayerList()) {
+            ManhuntManager.getInstance().setRunner(p.getUuid());
+        }
+
+        SelectorInventory inventory = new SelectorInventory(server);
+
+        player.openHandledScreen(
+                new SimpleNamedScreenHandlerFactory((syncId, playerInventory, playerEntity) -> {
+                    return new SelectorScreenHandler(syncId, inventory, player);
+                }, Text.literal("Select Runners & Hunters").formatted(Formatting.DARK_GRAY)));
+    }
+
+    /** Builds styled text for GUI items (non-italic, with given formatings). */
+    private static Text createItemName(String text, Formatting... formattings) {
+        Style style = Style.EMPTY.withItalic(false);
+        for (Formatting formatting : formattings) {
+            style = style.withFormatting(formatting);
+        }
+        return Text.literal(text).setStyle(style);
+    }
+
+    /**
+     * Inventory containing player heads and confirm button.
+     */
+    public static class SelectorInventory extends SimpleInventory {
+
+        private final MinecraftServer server;
+        private final List<UUID> playerOrder = new ArrayList<>();
+
+        public SelectorInventory(MinecraftServer server) {
+            super(INVENTORY_SIZE);
+            this.server = server;
+            populateItems();
+        }
+
+        public void populateItems() {
+            for (int i = 0; i < INVENTORY_SIZE; i++) {
+                setStack(i, createFillerItem());
+            }
+
+            playerOrder.clear();
+
+            List<ServerPlayerEntity> players = server.getPlayerManager().getPlayerList();
+            for (int i = 0; i < players.size() && i < HEAD_SLOTS.length; i++) {
+                int slot = HEAD_SLOTS[i];
+                ServerPlayerEntity p = players.get(i);
+                playerOrder.add(p.getUuid());
+                setStack(slot, createPlayerHead(p));
+            }
+
+            setStack(CONFIRM_SLOT, createConfirmItem());
+        }
+
+        private ItemStack createFillerItem() {
+            ItemStack filler = new ItemStack(Items.GRAY_STAINED_GLASS_PANE);
+            filler.set(DataComponentTypes.CUSTOM_NAME, Text.literal(" "));
+            return filler;
+        }
+
+        private ItemStack createPlayerHead(ServerPlayerEntity player) {
+            ItemStack head = new ItemStack(Items.PLAYER_HEAD);
+            head.set(DataComponentTypes.PROFILE, ProfileComponent.ofStatic(player.getGameProfile()));
+
+            boolean isRunner = ManhuntManager.getInstance().isSpeedrunner(player.getUuid());
+            String role = isRunner ? "RUNNER" : "HUNTER";
+            Formatting roleColor = isRunner ? Formatting.GREEN : Formatting.RED;
+
+            head.set(DataComponentTypes.CUSTOM_NAME, createItemName(player.getName().getString(),
+                    Formatting.WHITE, Formatting.BOLD));
+
+            LoreComponent lore = new LoreComponent(List.of(
+                    Text.literal("Role: ")
+                            .setStyle(Style.EMPTY.withItalic(false).withFormatting(Formatting.GRAY))
+                            .append(Text.literal(role).setStyle(
+                                    Style.EMPTY.withItalic(false).withFormatting(roleColor))),
+                    Text.empty(),
+                    isRunner
+                            ? Text.literal("Shares health with other Runners")
+                                    .setStyle(Style.EMPTY.withItalic(false)
+                                            .withFormatting(Formatting.DARK_GRAY))
+                            : Text.literal("Vanilla mechanics, hunts Runners")
+                                    .setStyle(Style.EMPTY.withItalic(false)
+                                            .withFormatting(Formatting.DARK_GRAY)),
+                    Text.empty(),
+                    Text.literal("Click to toggle role").setStyle(
+                            Style.EMPTY.withItalic(false).withFormatting(Formatting.YELLOW))));
+            head.set(DataComponentTypes.LORE, lore);
+
+            return head;
+        }
+
+        private ItemStack createConfirmItem() {
+            ItemStack item = new ItemStack(Items.EMERALD);
+            ManhuntManager manager = ManhuntManager.getInstance();
+            int runnerCount = manager.getRunners().size();
+            int hunterCount = manager.getHunters().size();
+            boolean canStart = runnerCount > 0 && hunterCount > 0;
+
+            if (canStart) {
+                item.set(DataComponentTypes.CUSTOM_NAME,
+                        createItemName("✓ Start Run", Formatting.GREEN, Formatting.BOLD));
+            } else {
+                item = new ItemStack(Items.BARRIER);
+                if (runnerCount == 0 && hunterCount == 0) {
+                    item.set(DataComponentTypes.CUSTOM_NAME, createItemName(
+                            "✗ Need Runners & Hunters", Formatting.RED, Formatting.BOLD));
+                } else if (runnerCount == 0) {
+                    item.set(DataComponentTypes.CUSTOM_NAME, createItemName(
+                            "✗ Need at least 1 Runner", Formatting.RED, Formatting.BOLD));
+                } else {
+                    item.set(DataComponentTypes.CUSTOM_NAME, createItemName(
+                            "✗ Need at least 1 Hunter", Formatting.RED, Formatting.BOLD));
+                }
+            }
+
+            LoreComponent lore = new LoreComponent(List.of(
+                    Text.literal("Runners: ")
+                            .setStyle(Style.EMPTY.withItalic(false).withFormatting(Formatting.GRAY))
+                            .append(Text.literal(String.valueOf(runnerCount))
+                                    .setStyle(Style.EMPTY.withItalic(false)
+                                            .withFormatting(Formatting.GREEN))),
+                    Text.literal("Hunters: ")
+                            .setStyle(Style.EMPTY.withItalic(false).withFormatting(Formatting.GRAY))
+                            .append(Text.literal(String.valueOf(hunterCount)).setStyle(
+                                    Style.EMPTY.withItalic(false).withFormatting(Formatting.RED))),
+                    Text.empty(),
+                    canStart ? Text.literal("Click to start the run!").setStyle(
+                            Style.EMPTY.withItalic(false).withFormatting(Formatting.YELLOW))
+                            : Text.literal("Need at least 1 Runner and 1 Hunter").setStyle(
+                                    Style.EMPTY.withItalic(false).withFormatting(Formatting.RED))));
+            item.set(DataComponentTypes.LORE, lore);
+
+            return item;
+        }
+
+        public UUID getPlayerAtSlot(int slot) {
+            for (int i = 0; i < HEAD_SLOTS.length && i < playerOrder.size(); i++) {
+                if (HEAD_SLOTS[i] == slot)
+                    return playerOrder.get(i);
+            }
+            return null;
+        }
+    }
+
+    private static class VirtualSlot extends Slot {
+        public VirtualSlot(Inventory inventory, int index, int x, int y) {
+            super(inventory, index, x, y);
+        }
+
+        @Override
+        public boolean canTakeItems(PlayerEntity playerEntity) {
+            return false;
+        }
+
+        @Override
+        public boolean canInsert(ItemStack stack) {
+            return false;
+        }
+
+        @Override
+        public boolean canBeHighlighted() {
+            return true;
+        }
+    }
+
+    /**
+     * Screen handler for the role selector GUI. Spectators can interact via SpectatorInteractionMixin.
+     */
+    public static class SelectorScreenHandler extends ScreenHandler {
+
+        private final SelectorInventory selectorInventory;
+        private final ServerPlayerEntity player;
+
+        public SelectorScreenHandler(int syncId, SelectorInventory inventory,
+                ServerPlayerEntity player) {
+            super(ScreenHandlerType.GENERIC_9X6, syncId);
+            this.selectorInventory = inventory;
+            this.player = player;
+            checkSize(inventory, INVENTORY_SIZE);
+            inventory.onOpen(player);
+
+            for (int i = 0; i < INVENTORY_SIZE; i++) {
+                int x = 8 + (i % 9) * 18;
+                int y = 18 + (i / 9) * 18;
+                this.addSlot(new VirtualSlot(inventory, i, x, y));
+            }
+
+            int headerOffset = 36;
+            for (int row = 0; row < 3; ++row) {
+                for (int col = 0; col < 9; ++col) {
+                    this.addSlot(new Slot(player.getInventory(), col + row * 9 + 9,
+                            8 + col * 18, 103 + row * 18 + headerOffset));
+                }
+            }
+            for (int col = 0; col < 9; ++col) {
+                this.addSlot(new Slot(player.getInventory(), col, 8 + col * 18, 161 + headerOffset));
+            }
+        }
+
+        @Override
+        public void onSlotClick(int slotIndex, int button, SlotActionType actionType,
+                PlayerEntity clickingPlayer) {
+            if (slotIndex < INVENTORY_SIZE && slotIndex >= 0) {
+                handleSelectorClick(slotIndex);
+
+                setCursorStack(ItemStack.EMPTY);
+
+                if (clickingPlayer instanceof ServerPlayerEntity serverPlayer
+                        && serverPlayer.interactionManager.getGameMode() == GameMode.SPECTATOR) {
+                    ScreenHandlerAccessor accessor = (ScreenHandlerAccessor) this;
+                    accessor.invokeUpdateToClient();
+                } else {
+                    sendContentUpdates();
+                }
+                return;
+            }
+            super.onSlotClick(slotIndex, button, actionType, clickingPlayer);
+        }
+
+        @Override
+        public ItemStack quickMove(PlayerEntity playerEntity, int slot) {
+            return ItemStack.EMPTY;
+        }
+
+        private void handleSelectorClick(int slotIndex) {
+            if (slotIndex == CONFIRM_SLOT) {
+                handleConfirm();
+                return;
+            }
+
+            UUID clickedPlayer = selectorInventory.getPlayerAtSlot(slotIndex);
+            if (clickedPlayer != null) {
+                ManhuntManager.getInstance().toggleRole(clickedPlayer);
+                selectorInventory.populateItems();
+                playClickSound();
+            }
+        }
+
+        private void handleConfirm() {
+            ManhuntManager manager = ManhuntManager.getInstance();
+
+            if (!manager.hasRunners()) {
+                player.sendMessage(RunManager.formatMessage("Need at least one Runner to start!"),
+                        false);
+                playErrorSound();
+                return;
+            }
+
+            if (!manager.hasHunters()) {
+                player.sendMessage(RunManager.formatMessage("Need at least one Hunter to start!"),
+                        false);
+                playErrorSound();
+                return;
+            }
+
+            // Run everything on the server main thread to avoid crashes: slot clicks can run
+            // on the network thread, while closeHandledScreen, startRun (world/chunk work) and
+            // broadcast must run on the main thread.
+            RunManager runManager = RunManager.getInstance();
+            if (runManager == null)
+                return;
+            MinecraftServer server = runManager.getServer();
+            if (server == null)
+                return;
+
+            server.execute(() -> {
+                if (player.isRemoved())
+                    return;
+                player.closeHandledScreen();
+                playConfirmSound();
+                broadcastRoleAssignments(server);
+                runManager.startRun();
+            });
+        }
+
+        /**
+         * Broadcasts Runner and Hunter role assignments to all players.
+         *
+         * @param server the server (must be non-null)
+         */
+        private void broadcastRoleAssignments(MinecraftServer server) {
+            ManhuntManager manager = ManhuntManager.getInstance();
+
+            List<String> runnerNames = new ArrayList<>();
+            for (UUID uuid : manager.getRunners()) {
+                ServerPlayerEntity p = server.getPlayerManager().getPlayer(uuid);
+                if (p != null) {
+                    runnerNames.add(p.getName().getString());
+                }
+            }
+
+            List<String> hunterNames = new ArrayList<>();
+            for (UUID uuid : manager.getHunters()) {
+                ServerPlayerEntity p = server.getPlayerManager().getPlayer(uuid);
+                if (p != null) {
+                    hunterNames.add(p.getName().getString());
+                }
+            }
+
+            if (!runnerNames.isEmpty()) {
+                Text runnerMsg = Text.empty().append(RunManager.getPrefix())
+                        .append(Text.literal("Runners: ").formatted(Formatting.GRAY))
+                        .append(Text.literal(String.join(", ", runnerNames))
+                                .formatted(Formatting.GREEN));
+                server.getPlayerManager().broadcast(runnerMsg, false);
+            }
+
+            if (!hunterNames.isEmpty()) {
+                Text hunterMsg = Text.empty().append(RunManager.getPrefix())
+                        .append(Text.literal("Hunters: ").formatted(Formatting.GRAY))
+                        .append(Text.literal(String.join(", ", hunterNames))
+                                .formatted(Formatting.RED));
+                server.getPlayerManager().broadcast(hunterMsg, false);
+            }
+        }
+
+        private void playClickSound() {
+            player.getEntityWorld().playSound(null, player.getX(), player.getY(), player.getZ(),
+                    SoundEvents.UI_BUTTON_CLICK.value(), SoundCategory.MASTER, 0.5f, 1.0f);
+        }
+
+        private void playConfirmSound() {
+            player.getEntityWorld().playSound(null, player.getX(), player.getY(), player.getZ(),
+                    SoundEvents.ENTITY_PLAYER_LEVELUP, SoundCategory.MASTER, 0.5f, 1.0f);
+        }
+
+        private void playErrorSound() {
+            player.getEntityWorld().playSound(null, player.getX(), player.getY(), player.getZ(),
+                    SoundEvents.ENTITY_VILLAGER_NO, SoundCategory.MASTER, 0.5f, 1.0f);
+        }
+
+        @Override
+        public boolean canUse(PlayerEntity playerEntity) {
+            return true;
+        }
+    }
+}

--- a/src/main/java/net/zenzty/soullink/server/manhunt/SpeedrunnerSelectorGui.java
+++ b/src/main/java/net/zenzty/soullink/server/manhunt/SpeedrunnerSelectorGui.java
@@ -38,13 +38,8 @@ public class SpeedrunnerSelectorGui {
 
     // Player head slots: top row and side columns (0, 8) are filler; content fills rows 1–5,
     // cols 1–7 with no gaps. Confirm at 49; heads use the rest in row-major order.
-    private static final int[] HEAD_SLOTS = {
-            10, 11, 12, 13, 14, 15, 16,
-            19, 20, 21, 22, 23, 24, 25,
-            28, 29, 30, 31, 32, 33, 34,
-            37, 38, 39, 40, 41, 42, 43,
-            46, 47, 48, 50, 51, 52
-    };
+    private static final int[] HEAD_SLOTS = {10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 24, 25,
+            28, 29, 30, 31, 32, 33, 34, 37, 38, 39, 40, 41, 42, 43, 46, 47, 48, 50, 51, 52};
 
     /**
      * Opens the role selector GUI for a player.
@@ -117,7 +112,8 @@ public class SpeedrunnerSelectorGui {
 
         private ItemStack createPlayerHead(ServerPlayerEntity player) {
             ItemStack head = new ItemStack(Items.PLAYER_HEAD);
-            head.set(DataComponentTypes.PROFILE, ProfileComponent.ofStatic(player.getGameProfile()));
+            head.set(DataComponentTypes.PROFILE,
+                    ProfileComponent.ofStatic(player.getGameProfile()));
 
             boolean isRunner = ManhuntManager.getInstance().isSpeedrunner(player.getUuid());
             String role = isRunner ? "RUNNER" : "HUNTER";
@@ -131,16 +127,14 @@ public class SpeedrunnerSelectorGui {
                             .setStyle(Style.EMPTY.withItalic(false).withFormatting(Formatting.GRAY))
                             .append(Text.literal(role).setStyle(
                                     Style.EMPTY.withItalic(false).withFormatting(roleColor))),
-                    Text.empty(),
-                    isRunner
+                    Text.empty(), isRunner
                             ? Text.literal("Shares health with other Runners")
                                     .setStyle(Style.EMPTY.withItalic(false)
                                             .withFormatting(Formatting.DARK_GRAY))
                             : Text.literal("Vanilla mechanics, hunts Runners")
                                     .setStyle(Style.EMPTY.withItalic(false)
                                             .withFormatting(Formatting.DARK_GRAY)),
-                    Text.empty(),
-                    Text.literal("Click to toggle role").setStyle(
+                    Text.empty(), Text.literal("Click to toggle role").setStyle(
                             Style.EMPTY.withItalic(false).withFormatting(Formatting.YELLOW))));
             head.set(DataComponentTypes.LORE, lore);
 
@@ -222,7 +216,8 @@ public class SpeedrunnerSelectorGui {
     }
 
     /**
-     * Screen handler for the role selector GUI. Spectators can interact via SpectatorInteractionMixin.
+     * Screen handler for the role selector GUI. Spectators can interact via
+     * SpectatorInteractionMixin.
      */
     public static class SelectorScreenHandler extends ScreenHandler {
 
@@ -246,12 +241,13 @@ public class SpeedrunnerSelectorGui {
             int headerOffset = 36;
             for (int row = 0; row < 3; ++row) {
                 for (int col = 0; col < 9; ++col) {
-                    this.addSlot(new Slot(player.getInventory(), col + row * 9 + 9,
-                            8 + col * 18, 103 + row * 18 + headerOffset));
+                    this.addSlot(new Slot(player.getInventory(), col + row * 9 + 9, 8 + col * 18,
+                            103 + row * 18 + headerOffset));
                 }
             }
             for (int col = 0; col < 9; ++col) {
-                this.addSlot(new Slot(player.getInventory(), col, 8 + col * 18, 161 + headerOffset));
+                this.addSlot(
+                        new Slot(player.getInventory(), col, 8 + col * 18, 161 + headerOffset));
             }
         }
 
@@ -285,12 +281,16 @@ public class SpeedrunnerSelectorGui {
                 handleConfirm();
                 return;
             }
-
             UUID clickedPlayer = selectorInventory.getPlayerAtSlot(slotIndex);
             if (clickedPlayer != null) {
-                ManhuntManager.getInstance().toggleRole(clickedPlayer);
-                selectorInventory.populateItems();
-                playClickSound();
+                MinecraftServer server = RunManager.getInstance().getServer();
+                if (server != null) {
+                    server.execute(() -> {
+                        ManhuntManager.getInstance().toggleRole(clickedPlayer);
+                        selectorInventory.populateItems();
+                        playClickSound();
+                    });
+                }
             }
         }
 
@@ -365,9 +365,8 @@ public class SpeedrunnerSelectorGui {
 
             if (!hunterNames.isEmpty()) {
                 Text hunterMsg = Text.empty().append(RunManager.getPrefix())
-                        .append(Text.literal("Hunters: ").formatted(Formatting.GRAY))
-                        .append(Text.literal(String.join(", ", hunterNames))
-                                .formatted(Formatting.RED));
+                        .append(Text.literal("Hunters: ").formatted(Formatting.GRAY)).append(Text
+                                .literal(String.join(", ", hunterNames)).formatted(Formatting.RED));
                 server.getPlayerManager().broadcast(hunterMsg, false);
             }
         }

--- a/src/main/java/net/zenzty/soullink/server/run/TimerService.java
+++ b/src/main/java/net/zenzty/soullink/server/run/TimerService.java
@@ -88,10 +88,14 @@ public class TimerService {
      *
      * @param server The Minecraft server
      * @param isInRunCheck Function to check if a player is in the run
+     * @param skipActionBarFor When this returns true for a player, the action bar (timer or ready
+     *        message) is not sent so other messages (e.g. compass tracking in Manhunt) can stay
+     *        visible
      * @return true if timer is running, false otherwise
      */
     public boolean tick(MinecraftServer server,
-            java.util.function.Predicate<ServerPlayerEntity> isInRunCheck) {
+            java.util.function.Predicate<ServerPlayerEntity> isInRunCheck,
+            java.util.function.Predicate<ServerPlayerEntity> skipActionBarFor) {
         // Wait for player input (movement or camera) to start timer
         if (waitingForInput) {
             if (checkForInput(server, isInRunCheck)) {
@@ -109,7 +113,7 @@ public class TimerService {
                             .append(Text.literal("00:00:00").formatted(Formatting.WHITE))
                             .append(Text.literal(" - Move to start").formatted(Formatting.GRAY));
                     for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
-                        if (isInRunCheck.test(player)) {
+                        if (isInRunCheck.test(player) && !skipActionBarFor.test(player)) {
                             player.sendMessage(readyText, true);
                         }
                     }
@@ -127,7 +131,7 @@ public class TimerService {
             Text actionBarText = Text.literal(getFormattedTime()).formatted(Formatting.WHITE);
 
             for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
-                if (isInRunCheck.test(player)) {
+                if (isInRunCheck.test(player) && !skipActionBarFor.test(player)) {
                     player.sendMessage(actionBarText, true);
                 }
             }

--- a/src/main/java/net/zenzty/soullink/server/settings/Settings.java
+++ b/src/main/java/net/zenzty/soullink/server/settings/Settings.java
@@ -18,6 +18,7 @@ public class Settings {
     private boolean halfHeartMode = false;
     private boolean sharedPotions = false;
     private boolean sharedJumping = false;
+    private boolean manhuntMode = false;
     private boolean damageLogEnabled = true; // Combat log - can be toggled immediately
 
     // Pending settings to be applied on next run
@@ -81,6 +82,31 @@ public class Settings {
         this.sharedJumping = sharedJumping;
     }
 
+    // ==================== MANHUNT MODE ====================
+
+    /**
+     * Whether Manhunt mode is enabled. When true, a Runner/Hunter selector is shown before the run.
+     * Runners share Soul Link (health, hunger); Hunters use vanilla mechanics and get tracking
+     * compasses.
+     */
+    public boolean isManhuntMode() {
+        return manhuntMode;
+    }
+
+    /**
+     * Whether Manhunt will be enabled for the next run. If the player confirmed changes in /chaos
+     * during an active run, those are pending and this returns the pending Manhunt value; otherwise
+     * the current setting. Use this when deciding to open the Runner/Hunter selector before
+     * startRun, because applyPendingSettings runs inside startRun.
+     */
+    public boolean isManhuntModeForNextRun() {
+        return pendingSnapshot != null ? pendingSnapshot.manhuntMode() : manhuntMode;
+    }
+
+    public void setManhuntMode(boolean manhuntMode) {
+        this.manhuntMode = manhuntMode;
+    }
+
     // ==================== DAMAGE LOG ====================
 
     public boolean isDamageLogEnabled() {
@@ -94,10 +120,20 @@ public class Settings {
     // ==================== UTILITY ====================
 
     /**
+     * Returns the pending snapshot if one exists (changes confirmed in /chaos during an active
+     * run). Used by the Chaos GUI to pre-fill with pending values so the player sees what is
+     * already queued instead of the in-memory (current-run) values.
+     */
+    public SettingsSnapshot getPendingSnapshotOrNull() {
+        return pendingSnapshot;
+    }
+
+    /**
      * Creates a copy of the current settings for temporary editing in the GUI.
      */
     public SettingsSnapshot createSnapshot() {
-        return new SettingsSnapshot(difficulty, halfHeartMode, sharedPotions, sharedJumping);
+        return new SettingsSnapshot(difficulty, halfHeartMode, sharedPotions, sharedJumping,
+                manhuntMode);
     }
 
     /**
@@ -111,7 +147,11 @@ public class Settings {
                 || runManager.getGameState() == RunState.GENERATING_WORLD);
 
         if (runActive) {
-            // Check if anything actually changed
+            // Already queued this exact snapshot (e.g. re-confirm without changing) – no-op
+            if (pendingSnapshot != null && snapshot.equals(pendingSnapshot)) {
+                return;
+            }
+            // User reverted to the current applied state – clear pending
             SettingsSnapshot current = createSnapshot();
             if (snapshot.equals(current)) {
                 this.pendingSnapshot = null;
@@ -136,10 +176,11 @@ public class Settings {
         this.halfHeartMode = snapshot.halfHeartMode();
         this.sharedPotions = snapshot.sharedPotions();
         this.sharedJumping = snapshot.sharedJumping();
+        this.manhuntMode = snapshot.manhuntMode();
 
         SoulLink.LOGGER.info(
-                "Settings applied: Difficulty={}, HalfHeart={}, SharedPotions={}, SharedJumping={}",
-                difficulty, halfHeartMode, sharedPotions, sharedJumping);
+                "Settings applied: Difficulty={}, HalfHeart={}, SharedPotions={}, SharedJumping={}, Manhunt={}",
+                difficulty, halfHeartMode, sharedPotions, sharedJumping, manhuntMode);
     }
 
     /**
@@ -157,6 +198,6 @@ public class Settings {
      * Immutable snapshot of settings for comparison and temporary editing.
      */
     public record SettingsSnapshot(Difficulty difficulty, boolean halfHeartMode,
-            boolean sharedPotions, boolean sharedJumping) {
+            boolean sharedPotions, boolean sharedJumping, boolean manhuntMode) {
     }
 }

--- a/src/main/java/net/zenzty/soullink/server/settings/SettingsInfoGui.java
+++ b/src/main/java/net/zenzty/soullink/server/settings/SettingsInfoGui.java
@@ -430,7 +430,8 @@ public class SettingsInfoGui {
                         player.networkHandler.sendPacket(
                                         new net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket(
                                                         net.minecraft.registry.Registries.SOUND_EVENT
-                                                                        .getEntry(net.minecraft.sound.SoundEvents.ENTITY_PLAYER_LEVELUP),
+                                                                        .getEntry(net.minecraft.sound.SoundEvents.UI_BUTTON_CLICK
+                                                                                        .value()),
                                                         net.minecraft.sound.SoundCategory.MASTER,
                                                         player.getX(), player.getY(), player.getZ(),
                                                         0.5f, 1.0f, player.getRandom().nextLong()));


### PR DESCRIPTION
- Added ManhuntManager to manage player roles (Runners and Hunters) and their interactions.
- Introduced SpeedrunnerSelectorGui for selecting roles before starting a run.
- Implemented compass tracking for Hunters to follow Runners' last known positions.
- Updated ServerPlayerEntityMixin to handle custom respawn mechanics for Hunters.
- Enhanced SharedStatsHandler to differentiate between Runners and Hunters in shared health mechanics.
- Modified RunManager to integrate Manhunt mode settings and player teleportation logic.
- Added event handling for player deaths and respawns specific to Manhunt mode.
- Updated Settings and SettingsGui to include Manhunt mode configuration options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manhunt mode: runner/hunter roles, role-selection GUI, teams, head-start effects, per-role spawn/teleport behavior, and respawn countdown for hunters
  * Compass-based hunter tracking with cross-dimension last-known locations and tracking compass item
  * Role-aware timer/action-bar suppression and selective shared-stats syncing

* **Bug Fixes / Tweaks**
  * Improved death handling and post-death cleanup per role
  * Settings GUI and sound/confirmation refinements; Manhunt setting added to workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->