### PR TITLE
feat: persist settings across server restarts

### DIFF
--- a/src/main/java/net/zenzty/soullink/server/event/EventRegistry.java
+++ b/src/main/java/net/zenzty/soullink/server/event/EventRegistry.java
@@ -36,6 +36,7 @@ import net.zenzty.soullink.server.manhunt.ManhuntManager;
 import net.zenzty.soullink.server.run.RunManager;
 import net.zenzty.soullink.server.run.RunState;
 import net.zenzty.soullink.server.settings.Settings;
+import net.zenzty.soullink.server.settings.SettingsPersistence;
 
 /**
  * Registers all Fabric events: server lifecycle, player connections, tick updates, entity events.
@@ -70,17 +71,19 @@ public class EventRegistry {
      * Registers server lifecycle events for initialization and cleanup.
      */
     private static void registerServerEvents() {
-        // Server started - initialize RunManager
+        // Server started - initialize RunManager and load persisted settings
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             SoulLink.LOGGER.info("Server started - initializing RunManager");
             RunManager.init(server);
+            SettingsPersistence.load(server);
             ManhuntManager.getInstance().resetRoles();
             ManhuntManager.getInstance().cleanupTeams(server);
         });
 
-        // Server stopping - cleanup worlds
+        // Server stopping - save settings, then cleanup worlds
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
-            SoulLink.LOGGER.info("Server stopping - cleaning up temporary worlds");
+            SoulLink.LOGGER.info("Server stopping - saving settings and cleaning up temporary worlds");
+            SettingsPersistence.save(server);
             delayedTasks.clear(); // Clear pending tasks
             RunManager.cleanup();
         });

--- a/src/main/java/net/zenzty/soullink/server/run/RunManager.java
+++ b/src/main/java/net/zenzty/soullink/server/run/RunManager.java
@@ -36,6 +36,7 @@ import net.zenzty.soullink.server.health.SharedStatsHandler;
 import net.zenzty.soullink.server.manhunt.CompassTrackingHandler;
 import net.zenzty.soullink.server.manhunt.ManhuntManager;
 import net.zenzty.soullink.server.settings.Settings;
+import net.zenzty.soullink.server.settings.SettingsPersistence;
 
 /**
  * Facade that coordinates run lifecycle using dedicated services. Manages game state transitions
@@ -158,6 +159,7 @@ public class RunManager {
 
         // Apply pending settings first so Manhunt and all Chaos options are correct for this run
         Settings.getInstance().applyPendingSettings();
+        SettingsPersistence.save(server);
 
         if (!Settings.getInstance().isManhuntMode()) {
             ManhuntManager.getInstance().resetRoles();

--- a/src/main/java/net/zenzty/soullink/server/settings/SettingsGui.java
+++ b/src/main/java/net/zenzty/soullink/server/settings/SettingsGui.java
@@ -627,6 +627,11 @@ public class SettingsGui {
                                                                 .applySnapshot(settingsInventory
                                                                                 .getPendingSnapshot());
                                                 confirmed = true;
+                                                MinecraftServer server = RunManager.getInstance()
+                                                                .getServer();
+                                                if (server != null) {
+                                                        SettingsPersistence.save(server);
+                                                }
 
                                                 // Broadcast changes to all players
                                                 broadcastChanges();

--- a/src/main/java/net/zenzty/soullink/server/settings/SettingsInfoGui.java
+++ b/src/main/java/net/zenzty/soullink/server/settings/SettingsInfoGui.java
@@ -15,6 +15,7 @@ import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.SimpleNamedScreenHandlerFactory;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.screen.slot.SlotActionType;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.Style;
@@ -399,6 +400,10 @@ public class SettingsInfoGui {
                                                                 settingsInventory
                                                                                 .isPendingDamageLog());
                                                 confirmed = true;
+                                                MinecraftServer server = RunManager.getInstance().getServer();
+                                                if (server != null) {
+                                                        SettingsPersistence.save(server);
+                                                }
 
                                                 player.sendMessage(RunManager.formatMessage(
                                                                 "Combat log " + (settingsInventory

--- a/src/main/java/net/zenzty/soullink/server/settings/SettingsPersistence.java
+++ b/src/main/java/net/zenzty/soullink/server/settings/SettingsPersistence.java
@@ -1,0 +1,138 @@
+package net.zenzty.soullink.server.settings;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.WorldSavePath;
+import net.minecraft.world.Difficulty;
+import net.zenzty.soullink.SoulLink;
+
+/**
+ * Handles loading and saving Soul Link settings to a JSON file in the world save directory.
+ * Settings persist across server restarts. The file format is extensible: missing keys on load keep
+ * current defaults; new settings can be added by extending the data class and load/save logic.
+ */
+public final class SettingsPersistence {
+
+    private static final String FILENAME = "soullink_settings.json";
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private SettingsPersistence() {}
+
+    /**
+     * Loads settings from the world save. If the file is missing or invalid, settings keep their
+     * in-memory defaults. Call after RunManager.init on SERVER_STARTED.
+     */
+    public static void load(MinecraftServer server) {
+        Path path = getSettingsPath(server);
+        if (!Files.isRegularFile(path)) {
+            SoulLink.LOGGER.debug("No settings file at {}, using defaults", path);
+            return;
+        }
+        try {
+            String json = Files.readString(path, StandardCharsets.UTF_8);
+            Object parsed = parseSettingsData(json);
+            if (parsed instanceof SettingsData data) {
+                applyToSettings(data);
+                SoulLink.LOGGER.info("Loaded Soul Link settings from {}", path);
+            }
+        } catch (IOException e) {
+            SoulLink.LOGGER.warn("Could not read settings file {}: {}", path, e.getMessage());
+        } catch (Exception e) {
+            SoulLink.LOGGER.warn("Could not parse settings file {}: {}", path, e.getMessage());
+        }
+    }
+
+    /**
+     * Saves current settings to the world save. Call when settings are changed (e.g. from /settings
+     * or /chaos) or on SERVER_STOPPING as a safety net.
+     */
+    public static void save(MinecraftServer server) {
+        Path path = getSettingsPath(server);
+        try {
+            SettingsData data = fromSettings();
+            String json = GSON.toJson(data);
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, json, StandardCharsets.UTF_8);
+            SoulLink.LOGGER.debug("Saved Soul Link settings to {}", path);
+        } catch (IOException e) {
+            SoulLink.LOGGER.warn("Could not write settings file {}: {}", path, e.getMessage());
+        }
+    }
+
+    private static Path getSettingsPath(MinecraftServer server) {
+        return server.getSavePath(WorldSavePath.ROOT).resolve(FILENAME);
+    }
+
+    /**
+     * Parses JSON into SettingsData. Returns Object so the result is not interpreted as @NonNull;
+     * Gson.fromJson can return null (e.g. for JSON "null") and Gson has no null annotations. Caller
+     * must use instanceof to check before using as SettingsData.
+     */
+    private static Object parseSettingsData(String json) {
+        return GSON.fromJson(json, SettingsData.class);
+    }
+
+    private static void applyToSettings(SettingsData data) {
+        Settings s = Settings.getInstance();
+        if (data.damageLogEnabled != null) {
+            s.setDamageLogEnabled(data.damageLogEnabled);
+        }
+        if (data.difficulty != null && !data.difficulty.isBlank()) {
+            try {
+                Difficulty d = Difficulty.valueOf(data.difficulty.toUpperCase());
+                s.setDifficulty(d);
+            } catch (IllegalArgumentException ignored) {
+                // keep default
+            }
+        }
+        if (data.halfHeartMode != null) {
+            s.setHalfHeartMode(data.halfHeartMode);
+        }
+        if (data.sharedPotions != null) {
+            s.setSharedPotions(data.sharedPotions);
+        }
+        if (data.sharedJumping != null) {
+            s.setSharedJumping(data.sharedJumping);
+        }
+        if (data.manhuntMode != null) {
+            s.setManhuntMode(data.manhuntMode);
+        }
+    }
+
+    private static SettingsData fromSettings() {
+        Settings s = Settings.getInstance();
+        SettingsData data = new SettingsData();
+        data.damageLogEnabled = s.isDamageLogEnabled();
+        // Use pending chaos snapshot if one exists (user confirmed /chaos changes during a run;
+        // those apply next run), otherwise use current applied values.
+        Settings.SettingsSnapshot chaos = s.getPendingSnapshotOrNull();
+        if (chaos == null) {
+            chaos = s.createSnapshot();
+        }
+        data.difficulty = chaos.difficulty().name();
+        data.halfHeartMode = chaos.halfHeartMode();
+        data.sharedPotions = chaos.sharedPotions();
+        data.sharedJumping = chaos.sharedJumping();
+        data.manhuntMode = chaos.manhuntMode();
+        return data;
+    }
+
+    /**
+     * DTO for JSON. Use boxed types so we can omit null on save and detect missing keys on load.
+     * When adding a new setting: add the field here, in applyToSettings, and in fromSettings.
+     * Fields are read and written by Gson via reflection, so they appear unused to the compiler.
+     */
+    private static class SettingsData {
+        Boolean damageLogEnabled;
+        String difficulty;
+        Boolean halfHeartMode;
+        Boolean sharedPotions;
+        Boolean sharedJumping;
+        Boolean manhuntMode;
+    }
+}


### PR DESCRIPTION
- Add SettingsPersistence to load/save settings from world/soullink_settings.json
- Load on SERVER_STARTED, save on SERVER_STOPPING and when settings change
- Persists: damageLogEnabled, difficulty, halfHeartMode, sharedPotions, sharedJumping, manhuntMode (chaos and /settings). Extensible for new fields.
- Wire save from SettingsInfoGui (combat log), SettingsGui (chaos), RunManager (after applyPendingSettings). Remove redundant same-package imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server settings are now automatically persisted and retained across server restarts
  * Settings changes are saved immediately when applied through the in-game interface
  * Configuration data is loaded at server startup and saved during shutdown to ensure all changes are preserved consistently

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->